### PR TITLE
Fix Incorrect Github Repository Config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,10 @@ gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
+  gem "jekyll-remote-theme"
   gem "jekyll-feed", "~> 0.6"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "jekyll-remote-theme"

--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,7 @@ logo: /assets/svg/logo.svg
 #remote_theme: "kadopoly/kadopoly.github.io.theme"
 remote_theme: "mmistakes/minimal-mistakes"
 
-#github:
-#  repository_url: https://github.com/kadopoly/kadopoly.github.io
+repository: kadopoly/kadopoly.github.io
 
 sass:
   style: compressed

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,7 @@ description: theme for kadopoly.github.io
 baseurl: ""
 url: ""
 logo: /assets/svg/logo.svg
-#remote_theme: "kadopoly/kadopoly.github.io.theme"
-remote_theme: "mmistakes/minimal-mistakes"
+remote_theme: kadopoly/kadopoly.github.io.theme
 
 repository: kadopoly/kadopoly.github.io
 
@@ -12,5 +11,5 @@ sass:
   style: compressed
 
 plugins:
-#  - jekyll-remote-theme
+  - jekyll-remote-theme
   - jekyll-feed


### PR DESCRIPTION
Fix errors where builds fail on Github Pages, with `github` entry present in `_config.yml`.

refs:
- https://help.github.com/articles/repository-metadata-on-github-pages/
- https://github.com/mmistakes/minimal-mistakes/issues/1992#issuecomment-453699142